### PR TITLE
simplify using markdown features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@ Documentation editor: Po-wei Huang
 
 Acknowledgement
 ==================
-I would like to thank the following people for their time, feedback, and contribution:<br/>
-Wei-Song
+I would like to thank the following peoples for their time, feedback, and contribution:<br/>
+Wei Song
 
 
 Tutorial on Spike Internal
 ==================
-*   [Goal of this document](#goal)
-*   [Which branch is being tageted?](#target)
-*   [Overview of Spike](#overview)
-*   [Top Level Structure](#Top)
-    *   [What does Spike try to model?](#model_top)
-    *   [Spike's source code](#source_top)
+*   [Goal of this document](#goal-of-this-document)
+*   [Which branch is being tageted?](#which-branch-is-being-tageted)
+*   [Overview of Spike](#overview-of-spike)
+*   [Top Level Structure](#top-level-structure)
+    *   [What is modelled by Spike?](#what-is-modelled-by-spike)
+    *   [Spike's source code](#spikes-source-code)
 *   [Memory System Overview](#Memory)
     *   [What does Spike try to model?](#model_memory)
 *   [TLB & MMU](#MMU_TLB)
@@ -38,35 +38,60 @@ Tutorial on Spike Internal
     *   [Device Simulation](#device_sim)
 *   [Appendix](#appendix)
     *   [Dealing with Instructions](#Instruction)
-<h2 id="goal">Goal of this document</h2>
-* Let people understand the implementation of Spike.<br/>
-* Work with Spike to help people understand RISC-V more as Spike is a golden reference<br/>
-* Provide information about how to use the spike, especially those features that are in the code but not well known to people. Ex. cache simulation, multi-core simulation.  <br/>
-<br/>
-As Spike is a functional simulator, the simulator structure would not necessarily match the hardware structure. In order to make simulation faster,  sometimes simulator optimization will be used, and these optimization will make the structure completely different. We will try to point out these difference when we meet them. <br/>
 
-<h2 id="target">Which branch is being tageted?</h2>
-This tutorial is for branch master from the RISC-V ISA SIM repo and the commit is daaf28f7296c0a5f5c90fe6646a4f8a73a720af5.<br/>
+Goal of this document
+-----------------
+* Let people understand the implementation of Spike.
+* Work with Spike to help people understand RISC-V more as Spike is a golden reference
+* Provide information about how to use the spike, especially those features that are in the code but not well known to people. Ex. cache simulation, multi-core simulation.
 
-<h2 id="overview">Overview of Spike</h2>
-1. Spike is an ISS (instruction set simulator), which is not cycle accurate. </br>
-2. Spike is a function simulator which omits all internal delays such as cache misses, memory transactions, IO accesses.</br>
-3. Spike does not have a full cache model, instead, the cache is a tracer or monitor (It doesn't allocate a space to cache any data). </br>
+As Spike is a functional simulator, the simulator structure would not necessarily match the hardware structure. In order to make simulation faster, sometimes simulator optimization will be used, and these optimization will make the structure completely different. We will try to point out these difference when we meet them.
 
-<h2 id="Top">Top Level Structure</h2>
-<h3 id="model_top">What does Spike try to model?</h3>
-For spike, they use a multi-core framework. Each core includes a MMU for virtual memory, and all of the core have a common I$ and D$. Then, both I$ and D$ connect to a single L2$. The main memory follows.  
+Which branch is being tageted?
+-----------------
+
+This tutorial is for branch master from the RISC-V ISA SIM repo and the commit is [daaf28f](https://github.com/riscv/riscv-isa-sim/tree/daaf28f7296c0a5f5c90fe6646a4f8a73a720af5).
+
+Overview of Spike
+-----------------
+1. Spike is an ISS (instruction set simulator), which is not cycle accurate.
+2. Spike is a function simulator which omits all internal delays such as cache misses, memory transactions, IO accesses.
+3. Spike does not have a full cache model, instead, the cache is a tracer or monitor (It doesn't allocate a space to cache any data).
+
+Top Level Structure
+-----------------
+
+### What is modelled by Spike?
+
+For spike, they use a multi-core framework. Each core includes a MMU for virtual memory, and all of the core have a common I$ and D$. Then, both I$ and D$ connect to a single L2$. The main memory follows.
   
 
-The cores and the memory hierarchy are inside a class sim, and the class could interact with outside by interactive command. Moreover, the sim includes  bus, debug module, boot rom, and real time clock (RTC) . The processors, boot ROM, debug module and RTC are hooked on the bus, but the memory is not. These components together enable spike to run a simple proxy kernel pk.  
+The cores and the memory hierarchy are inside a class sim, and the class could interact with outside by interactive command. Moreover, the sim includes  bus, debug module, boot rom, and real time clock (RTC) . The processors, boot ROM, debug module and RTC are hooked on the bus, but the memory is not. These components together enable spike to run a simple proxy kernel pk.
   
-![Top level overview](./pictures/Sim.png)  
-<h3 id="source_top">Spike's source code</h3>
-	The code below comes from riscv-isa-sim/spike_main/spike.cc. You could see that I$ and D$ connect to L2$ by miss handler. Moreover, for each core, it has a mmu and the mmu connect to a single ic and dc.  
-After all the components are connected, the method run is called to start the simulation.  
+![Top level overview](./pictures/Sim.png)
 
-![Source of Top](./pictures/Spike_main.png)  
-	On the other hand, inside riscv-isa-sim/riscv/sim.cc, you could see many bus.add_device(), just like the following figure shows. Spike use this function to attach device on bus. After these attachments are done, spike could start to run.  
+### Spike's source code
+
+The code below comes from `riscv-isa-sim/spike_main/spike.cc`. You could see that I$ and D$ connect to L2$ by miss handler. Moreover, for each core, it has a mmu and the mmu connect to a single ic and dc.
+After all the components are connected, the method run is called to start the simulation.
+
+~~~cpp
+  if (ic && l2) ic->set_miss_handler(&*l2);
+  if (dc && l2) dc->set_miss_handler(&*l2);
+  for (size_t i = 0; i < nprocs; i++)
+  {
+    if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
+    if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
+    if (extension) s.get_core(i)->register_extension(extension());
+  }
+
+  s.set_debug(debug);
+  s.set_log(log);
+  s.set_histogram(histogram);
+  return s.run();
+~~~
+
+On the other hand, inside riscv-isa-sim/riscv/sim.cc, you could see many bus.add_device(), just like the following figure shows. Spike use this function to attach device on bus. After these attachments are done, spike could start to run.  
 	
 ![Source of Bus add](./pictures/Bus_Add_device.png)  
 


### PR DESCRIPTION
Extra suggestion: so many identical headers, such as "what does Spike try to model" and "Spike's source code?", are not ideal.